### PR TITLE
feat: add run command for profiled execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- `run` command: launch an executable with profiler env vars attached (`--detach` for GUI apps)

--- a/src/Metreja.Tool/Commands/RunCommand.cs
+++ b/src/Metreja.Tool/Commands/RunCommand.cs
@@ -1,0 +1,111 @@
+using System.CommandLine;
+using System.Diagnostics;
+using Metreja.Tool.Config;
+
+namespace Metreja.Tool.Commands;
+
+public static class RunCommand
+{
+    public static Command Create()
+    {
+        var sessionOption = new Option<string>("--session", "-s")
+        {
+            Description = "Session ID for profiler config",
+            Required = true
+        };
+
+        var detachOption = new Option<bool>("--detach")
+        {
+            Description = "Launch and return immediately (for GUI/long-running apps)"
+        };
+
+        var exeArgument = new Argument<string>("exe-path")
+        {
+            Description = "Path to the executable to profile"
+        };
+
+        var extraArgsArgument = new Argument<string[]>("extra-args")
+        {
+            Description = "Additional arguments passed to the executable",
+            Arity = ArgumentArity.ZeroOrMore
+        };
+
+        var command = new Command("run", "Launch an executable with profiler environment variables attached");
+        command.Options.Add(sessionOption);
+        command.Options.Add(detachOption);
+        command.Arguments.Add(exeArgument);
+        command.Arguments.Add(extraArgsArgument);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var session = parseResult.GetValue(sessionOption)!;
+            var detach = parseResult.GetValue(detachOption);
+            var exePath = parseResult.GetValue(exeArgument)!;
+            var extraArgs = parseResult.GetValue(extraArgsArgument) ?? [];
+
+            // 1. Resolve profiler DLL
+            var profilerPath = ProfilerLocator.GetDefaultProfilerPath();
+            if (string.IsNullOrEmpty(profilerPath) || !File.Exists(profilerPath))
+            {
+                Console.Error.WriteLine("Error: Profiler DLL not found. Ensure Metreja.Profiler.dll is adjacent to the CLI assembly.");
+                Environment.ExitCode = 1;
+                return;
+            }
+            var absoluteDllPath = Path.GetFullPath(profilerPath);
+
+            // 2. Resolve session config
+            var manager = new ConfigManager();
+            var configPath = manager.GetSessionPath(session);
+            if (!File.Exists(configPath))
+            {
+                Console.Error.WriteLine($"Error: Session '{session}' not found at {configPath}");
+                Environment.ExitCode = 1;
+                return;
+            }
+            var absoluteConfigPath = Path.GetFullPath(configPath);
+
+            // 3. Resolve exe path
+            var absoluteExePath = Path.GetFullPath(exePath);
+            if (!File.Exists(absoluteExePath))
+            {
+                Console.Error.WriteLine($"Error: Executable not found at {absoluteExePath}");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            // 4. Create ProcessStartInfo with profiler env vars
+            var psi = new ProcessStartInfo
+            {
+                FileName = absoluteExePath,
+                Arguments = string.Join(' ', extraArgs),
+                UseShellExecute = false
+            };
+            psi.Environment["CORECLR_ENABLE_PROFILING"] = "1";
+            psi.Environment["CORECLR_PROFILER"] = MetrejaConstants.ProfilerClsid;
+            psi.Environment["CORECLR_PROFILER_PATH"] = absoluteDllPath;
+            psi.Environment["METREJA_CONFIG"] = absoluteConfigPath;
+
+            // 5. Launch
+            var process = Process.Start(psi);
+            if (process == null)
+            {
+                Console.Error.WriteLine("Error: Failed to start process.");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            if (detach)
+            {
+                Console.WriteLine($"Launched with PID {process.Id}");
+                Environment.ExitCode = 0;
+            }
+            else
+            {
+                await process.WaitForExitAsync(cancellationToken);
+                Environment.ExitCode = process.ExitCode;
+            }
+        });
+
+        return command;
+    }
+}

--- a/src/Metreja.Tool/Program.cs
+++ b/src/Metreja.Tool/Program.cs
@@ -10,6 +10,7 @@ rootCommand.Subcommands.Add(ClearFiltersCommand.Create());
 rootCommand.Subcommands.Add(SetCommand.Create());
 rootCommand.Subcommands.Add(ValidateCommand.Create());
 rootCommand.Subcommands.Add(GenerateEnvCommand.Create());
+rootCommand.Subcommands.Add(RunCommand.Create());
 rootCommand.Subcommands.Add(ClearCommand.Create());
 rootCommand.Subcommands.Add(AnalyzeDiffCommand.Create());
 rootCommand.Subcommands.Add(HotspotsCommand.Create());


### PR DESCRIPTION
## Summary
- Adds new `metreja run -s <session> [--detach] <exe> [args...]` command
- Launches target executable with profiler env vars injected via `ProcessStartInfo.Environment`
- `--detach` flag for GUI/long-running apps (prints PID and returns immediately)
- Eliminates need for batch scripts or shell state persistence when launching profiled apps

## Test plan
- [x] Build succeeds on all three TFMs (net8.0, net9.0, net10.0)
- [x] `metreja run --help` shows correct usage
- [ ] Run `metreja run -s <session> --detach <exe>` and confirm correct env var injection
- [ ] Verify non-detach mode waits for process exit and returns its exit code

🤖 Generated with [Claude Code](https://claude.com/claude-code)