### PR TITLE
Add run command and simplify filter rules

### DIFF
--- a/src/Metreja.Profiler/ConfigReader.cpp
+++ b/src/Metreja.Profiler/ConfigReader.cpp
@@ -85,14 +85,10 @@ ProfilerConfig ConfigReader::Load()
             for (const auto& item : arr)
             {
                 FilterRule rule;
-                if (item.contains("assembly"))
-                    rule.assembly = item["assembly"].get<std::string>();
-                if (item.contains("namespace"))
-                    rule.nameSpace = item["namespace"].get<std::string>();
-                if (item.contains("class"))
-                    rule.cls = item["class"].get<std::string>();
-                if (item.contains("method"))
-                    rule.method = item["method"].get<std::string>();
+                if (item.contains("level"))
+                    rule.level = item["level"].get<std::string>();
+                if (item.contains("pattern"))
+                    rule.pattern = item["pattern"].get<std::string>();
                 rules.push_back(rule);
             }
         };

--- a/src/Metreja.Profiler/ConfigReader.h
+++ b/src/Metreja.Profiler/ConfigReader.h
@@ -6,10 +6,8 @@
 
 struct FilterRule
 {
-    std::string assembly = "*";
-    std::string nameSpace = "*";
-    std::string cls = "*";
-    std::string method = "*";
+    std::string level = "assembly"; // "assembly", "namespace", "class", "method"
+    std::string pattern = "*";
 };
 
 struct ProfilerConfig

--- a/src/Metreja.Profiler/MethodCache.cpp
+++ b/src/Metreja.Profiler/MethodCache.cpp
@@ -182,6 +182,20 @@ std::string MethodCache::ResolveClassName(ClassID classId) const
     return "Unknown";
 }
 
+bool MethodCache::MatchesRule(const FilterRule& rule, const std::string& assembly, const std::string& ns,
+                              const std::string& cls, const std::string& method) const
+{
+    if (rule.level == "assembly")
+        return ConfigReader::SimpleGlobMatch(rule.pattern, assembly);
+    if (rule.level == "namespace")
+        return ConfigReader::SimpleGlobMatch(rule.pattern, ns);
+    if (rule.level == "class")
+        return ConfigReader::SimpleGlobMatch(rule.pattern, cls);
+    if (rule.level == "method")
+        return ConfigReader::SimpleGlobMatch(rule.pattern, method);
+    return false;
+}
+
 bool MethodCache::EvaluateFilters(const std::string& assembly, const std::string& ns, const std::string& cls,
                                   const std::string& method) const
 {
@@ -191,9 +205,7 @@ bool MethodCache::EvaluateFilters(const std::string& assembly, const std::string
     // Check includes
     for (const auto& rule : m_config.includes)
     {
-        if (ConfigReader::SimpleGlobMatch(rule.assembly, assembly) &&
-            ConfigReader::SimpleGlobMatch(rule.nameSpace, ns) && ConfigReader::SimpleGlobMatch(rule.cls, cls) &&
-            ConfigReader::SimpleGlobMatch(rule.method, method))
+        if (MatchesRule(rule, assembly, ns, cls, method))
         {
             included = true;
             break;
@@ -206,9 +218,7 @@ bool MethodCache::EvaluateFilters(const std::string& assembly, const std::string
     // Check excludes
     for (const auto& rule : m_config.excludes)
     {
-        if (ConfigReader::SimpleGlobMatch(rule.assembly, assembly) &&
-            ConfigReader::SimpleGlobMatch(rule.nameSpace, ns) && ConfigReader::SimpleGlobMatch(rule.cls, cls) &&
-            ConfigReader::SimpleGlobMatch(rule.method, method))
+        if (MatchesRule(rule, assembly, ns, cls, method))
         {
             return false;
         }

--- a/src/Metreja.Profiler/MethodCache.h
+++ b/src/Metreja.Profiler/MethodCache.h
@@ -38,6 +38,8 @@ public:
     static std::string WideToUtf8(const WCHAR* wide, int len = -1);
 
 private:
+    bool MatchesRule(const FilterRule& rule, const std::string& assembly, const std::string& ns,
+                     const std::string& cls, const std::string& method) const;
     bool EvaluateFilters(const std::string& assembly, const std::string& ns, const std::string& cls,
                          const std::string& method) const;
     bool IsAsyncStateMachine(const std::string& className, const std::string& methodName) const;

--- a/src/Metreja.Tool/Commands/AddCommand.cs
+++ b/src/Metreja.Tool/Commands/AddCommand.cs
@@ -28,23 +28,23 @@ public static class AddCommand
     {
         var assemblyOption = new Option<string[]>("--assembly")
         {
-            Description = "Assembly name pattern (default: *)",
-            Arity = ArgumentArity.ZeroOrMore
+            Description = "Assembly name pattern(s)",
+            Arity = ArgumentArity.OneOrMore
         };
         var namespaceOption = new Option<string[]>("--namespace")
         {
-            Description = "Namespace pattern (default: *)",
-            Arity = ArgumentArity.ZeroOrMore
+            Description = "Namespace pattern(s)",
+            Arity = ArgumentArity.OneOrMore
         };
         var classOption = new Option<string[]>("--class")
         {
-            Description = "Class name pattern (default: *)",
-            Arity = ArgumentArity.ZeroOrMore
+            Description = "Class name pattern(s)",
+            Arity = ArgumentArity.OneOrMore
         };
         var methodOption = new Option<string[]>("--method")
         {
-            Description = "Method name pattern (default: *)",
-            Arity = ArgumentArity.ZeroOrMore
+            Description = "Method name pattern(s)",
+            Arity = ArgumentArity.OneOrMore
         };
         var command = new Command(name, description);
         command.Options.Add(sessionOption);
@@ -56,18 +56,33 @@ public static class AddCommand
         command.SetAction(async (parseResult, _) =>
         {
             var session = parseResult.GetValue(sessionOption)!;
-            var assemblies = parseResult.GetValue(assemblyOption) ?? [];
-            var namespaces = parseResult.GetValue(namespaceOption) ?? [];
-            var classes = parseResult.GetValue(classOption) ?? [];
-            var methods = parseResult.GetValue(methodOption) ?? [];
-            if (!TryBuildRules(assemblies, namespaces, classes, methods, out var rules))
+
+            var provided = new (string[] values, string level)[]
             {
-                Console.Error.WriteLine(
-                    "Error: Only one filter option can have multiple values per command. " +
-                    "Run the command multiple times for complex combinations.");
+                (parseResult.GetValue(assemblyOption) ?? [], "assembly"),
+                (parseResult.GetValue(namespaceOption) ?? [], "namespace"),
+                (parseResult.GetValue(classOption) ?? [], "class"),
+                (parseResult.GetValue(methodOption) ?? [], "method")
+            };
+
+            var active = provided.Where(o => o.values.Length > 0).ToArray();
+
+            if (active.Length == 0)
+            {
+                Console.Error.WriteLine("Error: Specify one of --assembly, --namespace, --class, or --method.");
                 Environment.ExitCode = 1;
                 return;
             }
+
+            if (active.Length > 1)
+            {
+                Console.Error.WriteLine("Error: Only one level option (--assembly, --namespace, --class, --method) can be used per command.");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            var (values, level) = active[0];
+            var rules = values.Select(v => new FilterRule { Level = level, Pattern = v }).ToList();
 
             var manager = new ConfigManager();
             var config = await manager.LoadConfigAsync(session);
@@ -84,57 +99,5 @@ public static class AddCommand
         });
 
         return command;
-    }
-
-    private static bool TryBuildRules(
-        string[] assemblies, string[] namespaces, string[] classes, string[] methods,
-        out List<FilterRule> rules)
-    {
-        rules = [];
-        var multiValueOptions = new (string[] values, string label)[]
-        {
-            (assemblies, "assembly"),
-            (namespaces, "namespace"),
-            (classes, "class"),
-            (methods, "method")
-        };
-
-        var multiCount = multiValueOptions.Count(o => o.values.Length > 1);
-        if (multiCount > 1)
-            return false;
-
-        var multiOption = multiValueOptions.FirstOrDefault(o => o.values.Length > 1);
-
-        if (multiOption.values is null || multiOption.values.Length == 0)
-        {
-            rules =
-            [
-                new FilterRule
-                {
-                    Assembly = assemblies.Length == 1 ? assemblies[0] : "*",
-                    Namespace = namespaces.Length == 1 ? namespaces[0] : "*",
-                    Class = classes.Length == 1 ? classes[0] : "*",
-                    Method = methods.Length == 1 ? methods[0] : "*"
-                }
-            ];
-            return true;
-        }
-
-        var baseAssembly = assemblies.Length == 1 ? assemblies[0] : "*";
-        var baseNamespace = namespaces.Length == 1 ? namespaces[0] : "*";
-        var baseClass = classes.Length == 1 ? classes[0] : "*";
-        var baseMethod = methods.Length == 1 ? methods[0] : "*";
-
-        rules =
-        [
-            .. multiOption.values.Select(value => new FilterRule
-            {
-                Assembly = multiOption.label == "assembly" ? value : baseAssembly,
-                Namespace = multiOption.label == "namespace" ? value : baseNamespace,
-                Class = multiOption.label == "class" ? value : baseClass,
-                Method = multiOption.label == "method" ? value : baseMethod
-            })
-        ];
-        return true;
     }
 }

--- a/src/Metreja.Tool/Commands/RemoveCommand.cs
+++ b/src/Metreja.Tool/Commands/RemoveCommand.cs
@@ -26,14 +26,10 @@ public static class RemoveCommand
 
     private static Command CreateFilterRemoveCommand(string name, string description, Option<string> sessionOption)
     {
-        var assemblyOption = new Option<string>("--assembly") { Description = "Assembly name pattern (default: *)" };
-        assemblyOption.DefaultValueFactory = _ => "*";
-        var namespaceOption = new Option<string>("--namespace") { Description = "Namespace pattern (default: *)" };
-        namespaceOption.DefaultValueFactory = _ => "*";
-        var classOption = new Option<string>("--class") { Description = "Class name pattern (default: *)" };
-        classOption.DefaultValueFactory = _ => "*";
-        var methodOption = new Option<string>("--method") { Description = "Method name pattern (default: *)" };
-        methodOption.DefaultValueFactory = _ => "*";
+        var assemblyOption = new Option<string>("--assembly") { Description = "Assembly name pattern" };
+        var namespaceOption = new Option<string>("--namespace") { Description = "Namespace pattern" };
+        var classOption = new Option<string>("--class") { Description = "Class name pattern" };
+        var methodOption = new Option<string>("--method") { Description = "Method name pattern" };
         var command = new Command(name, description);
         command.Options.Add(sessionOption);
         command.Options.Add(assemblyOption);
@@ -44,13 +40,33 @@ public static class RemoveCommand
         command.SetAction(async (parseResult, _) =>
         {
             var session = parseResult.GetValue(sessionOption)!;
-            var rule = new FilterRule
+
+            var provided = new (string? value, string level)[]
             {
-                Assembly = parseResult.GetValue(assemblyOption)!,
-                Namespace = parseResult.GetValue(namespaceOption)!,
-                Class = parseResult.GetValue(classOption)!,
-                Method = parseResult.GetValue(methodOption)!
+                (parseResult.GetValue(assemblyOption), "assembly"),
+                (parseResult.GetValue(namespaceOption), "namespace"),
+                (parseResult.GetValue(classOption), "class"),
+                (parseResult.GetValue(methodOption), "method")
             };
+
+            var active = provided.Where(o => o.value is not null).ToArray();
+
+            if (active.Length == 0)
+            {
+                Console.Error.WriteLine("Error: Specify one of --assembly, --namespace, --class, or --method.");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            if (active.Length > 1)
+            {
+                Console.Error.WriteLine("Error: Only one level option (--assembly, --namespace, --class, --method) can be used per command.");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            var (pattern, level) = active[0];
+            var rule = new FilterRule { Level = level, Pattern = pattern! };
 
             var manager = new ConfigManager();
             var config = await manager.LoadConfigAsync(session);

--- a/src/Metreja.Tool/Config/ConfigManager.cs
+++ b/src/Metreja.Tool/Config/ConfigManager.cs
@@ -30,6 +30,10 @@ public class ConfigManager
             Metadata = new MetadataConfig
             {
                 Scenario = scenario ?? ""
+            },
+            Instrumentation = new InstrumentationConfig
+            {
+                Excludes = DefaultFilters.Excludes
             }
         };
 

--- a/src/Metreja.Tool/Config/ProfilerConfig.cs
+++ b/src/Metreja.Tool/Config/ProfilerConfig.cs
@@ -46,17 +46,20 @@ public record InstrumentationConfig
 
 public record FilterRule
 {
-    [JsonPropertyName("assembly")]
-    public string Assembly { get; init; } = "*";
+    [JsonPropertyName("level")]
+    public string Level { get; init; } = "assembly";
 
-    [JsonPropertyName("namespace")]
-    public string Namespace { get; init; } = "*";
+    [JsonPropertyName("pattern")]
+    public string Pattern { get; init; } = "*";
+}
 
-    [JsonPropertyName("class")]
-    public string Class { get; init; } = "*";
-
-    [JsonPropertyName("method")]
-    public string Method { get; init; } = "*";
+public static class DefaultFilters
+{
+    public static List<FilterRule> Excludes =>
+    [
+        new FilterRule { Level = "assembly", Pattern = "System.*" },
+        new FilterRule { Level = "assembly", Pattern = "Microsoft.*" }
+    ];
 }
 
 public record OutputConfig

--- a/test/Metreja.IntegrationTests/Infrastructure/ProfilerRunner.cs
+++ b/test/Metreja.IntegrationTests/Infrastructure/ProfilerRunner.cs
@@ -45,12 +45,12 @@ public sealed class ProfilerRunner : IAsyncDisposable
                 {
                     Includes =
                     [
-                        new FilterRule { Assembly = "Metreja.TestApp" }
+                        new FilterRule { Level = "assembly", Pattern = "Metreja.TestApp" }
                     ],
                     Excludes =
                     [
-                        new FilterRule { Assembly = "System.*" },
-                        new FilterRule { Assembly = "Microsoft.*" }
+                        new FilterRule { Level = "assembly", Pattern = "System.*" },
+                        new FilterRule { Level = "assembly", Pattern = "Microsoft.*" }
                     ]
                 },
                 Output = config.Output with


### PR DESCRIPTION
## Summary

- **`metreja run` command**: Launch profiled executables directly — injects `COR_PROFILER` env vars via `ProcessStartInfo`, supports `--detach` for long-running/GUI apps
- **Simplified FilterRule model**: Changed from 4-field AND model (`assembly`/`namespace`/`class`/`method`) to single-level `level` + `pattern`. Filter options are now mutually exclusive per call.
- **Default framework excludes**: New sessions automatically exclude `System.*` and `Microsoft.*` assemblies

## Test plan

- [x] C# build: 0 warnings, 0 errors (all TFMs)
- [x] C++ build: 0 errors
- [x] Integration tests: 28/28 passed
- [ ] Manual: `metreja init` → verify session JSON contains default excludes in new format
- [ ] Manual: `metreja run -s <id> <exe>` launches profiled app successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)