### PR TITLE
feat: support method_stats in hotspots and analyze-diff

### DIFF
--- a/src/Metreja.Tool/Analysis/DiffAnalyzer.cs
+++ b/src/Metreja.Tool/Analysis/DiffAnalyzer.cs
@@ -56,31 +56,19 @@ public static class DiffAnalyzer
 
                 var eventType = eventProp.GetString();
 
-                if (eventType == "leave")
+                long? timing = eventType switch
                 {
-                    var asm = root.TryGetProperty("asm", out var a) ? a.GetString() ?? "" : "";
-                    var (ns, cls, m) = AnalyzerHelpers.ExtractMethodInfo(root);
-                    var deltaNs = root.TryGetProperty("deltaNs", out var d) ? d.GetInt64() : 0;
+                    "leave" => root.TryGetProperty("deltaNs", out var d) ? d.GetInt64() : 0,
+                    "method_stats" => root.TryGetProperty("totalInclusiveNs", out var inc) ? inc.GetInt64() : 0,
+                    _ => null
+                };
 
-                    var key = $"{asm}.{ns}.{cls}.{m}";
-
-                    if (timings.TryGetValue(key, out var existing))
-                        timings[key] = existing + deltaNs;
-                    else
-                        timings[key] = deltaNs;
-                }
-                else if (eventType == "method_stats")
+                if (timing is not null)
                 {
-                    var asm = root.TryGetProperty("asm", out var a) ? a.GetString() ?? "" : "";
                     var (ns, cls, m) = AnalyzerHelpers.ExtractMethodInfo(root);
-                    var totalSelfNs = root.TryGetProperty("totalSelfNs", out var sn) ? sn.GetInt64() : 0;
+                    var key = AnalyzerHelpers.BuildMethodKey(ns, cls, m);
 
-                    var key = $"{asm}.{ns}.{cls}.{m}";
-
-                    if (timings.TryGetValue(key, out var existing))
-                        timings[key] = existing + totalSelfNs;
-                    else
-                        timings[key] = totalSelfNs;
+                    timings[key] = timings.GetValueOrDefault(key, 0) + timing.Value;
                 }
             }
             catch (JsonException)

--- a/src/Metreja.Tool/Analysis/HotspotsAnalyzer.cs
+++ b/src/Metreja.Tool/Analysis/HotspotsAnalyzer.cs
@@ -64,25 +64,29 @@ public static class HotspotsAnalyzer
                     continue;
 
                 var eventType = eventProp.GetString();
-                var (ns, cls, m) = AnalyzerHelpers.ExtractMethodInfo(root);
-                var tid = root.TryGetProperty("tid", out var t) ? t.GetInt64() : 0;
-                var key = AnalyzerHelpers.BuildMethodKey(ns, cls, m);
-
-                if (!threadStacks.TryGetValue(tid, out var stack))
-                {
-                    stack = new Stack<StackFrame>();
-                    threadStacks[tid] = stack;
-                }
 
                 if (eventType == "enter")
                 {
+                    var tid = root.TryGetProperty("tid", out var t) ? t.GetInt64() : 0;
+                    var (ns, cls, m) = AnalyzerHelpers.ExtractMethodInfo(root);
+                    var key = AnalyzerHelpers.BuildMethodKey(ns, cls, m);
+
+                    if (!threadStacks.TryGetValue(tid, out var stack))
+                    {
+                        stack = new Stack<StackFrame>();
+                        threadStacks[tid] = stack;
+                    }
+
                     stack.Push(new StackFrame { Key = key });
                 }
                 else if (eventType == "leave")
                 {
+                    var tid = root.TryGetProperty("tid", out var t) ? t.GetInt64() : 0;
+                    var (ns, cls, m) = AnalyzerHelpers.ExtractMethodInfo(root);
+                    var key = AnalyzerHelpers.BuildMethodKey(ns, cls, m);
                     var deltaNs = root.TryGetProperty("deltaNs", out var d) ? d.GetInt64() : 0;
 
-                    if (stack.Count > 0)
+                    if (threadStacks.TryGetValue(tid, out var stack) && stack.Count > 0)
                     {
                         var frame = stack.Pop();
                         var selfNs = deltaNs - frame.ChildrenNs;
@@ -110,6 +114,9 @@ public static class HotspotsAnalyzer
                 }
                 else if (eventType == "method_stats")
                 {
+                    var (ns, cls, m) = AnalyzerHelpers.ExtractMethodInfo(root);
+                    var key = AnalyzerHelpers.BuildMethodKey(ns, cls, m);
+
                     if (!hasFilters || MatchesAnyFilter(filters, ns, cls, m, key))
                     {
                         if (!stats.TryGetValue(key, out var ms))
@@ -118,7 +125,7 @@ public static class HotspotsAnalyzer
                             stats[key] = ms;
                         }
 
-                        ms.Count += (int)(root.TryGetProperty("callCount", out var cc) ? cc.GetInt64() : 0);
+                        ms.Count += root.TryGetProperty("callCount", out var cc) ? cc.GetInt64() : 0;
                         ms.SelfTotal += root.TryGetProperty("totalSelfNs", out var sn) ? sn.GetInt64() : 0;
                         ms.SelfMax = Math.Max(ms.SelfMax, root.TryGetProperty("maxSelfNs", out var smx) ? smx.GetInt64() : 0);
                         ms.InclusiveTotal += root.TryGetProperty("totalInclusiveNs", out var inc) ? inc.GetInt64() : 0;
@@ -127,8 +134,10 @@ public static class HotspotsAnalyzer
                 }
                 else if (eventType == "alloc_by_class")
                 {
+                    var tid = root.TryGetProperty("tid", out var t) ? t.GetInt64() : 0;
                     var allocCount = root.TryGetProperty("count", out var c) ? c.GetInt64() : 0;
-                    if (allocCount > 0 && stack.Count > 0)
+
+                    if (allocCount > 0 && threadStacks.TryGetValue(tid, out var stack) && stack.Count > 0)
                     {
                         var topKey = stack.Peek().Key;
                         if (!stats.TryGetValue(topKey, out var ms))
@@ -174,7 +183,7 @@ public static class HotspotsAnalyzer
 
     private sealed class MethodStats
     {
-        public int Count { get; set; }
+        public long Count { get; set; }
         public long InclusiveTotal { get; set; }
         public long InclusiveMax { get; set; }
         public long SelfTotal { get; set; }

--- a/src/Metreja.Tool/Metreja.Tool.csproj
+++ b/src/Metreja.Tool/Metreja.Tool.csproj
@@ -22,6 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Metreja.IntegrationTests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.3" />
   </ItemGroup>
 

--- a/test/Metreja.IntegrationTests/Tests/DiffAnalysisTests.cs
+++ b/test/Metreja.IntegrationTests/Tests/DiffAnalysisTests.cs
@@ -34,7 +34,7 @@ public class DiffAnalysisTests : IAsyncLifetime
             """{"event":"leave","tsNs":1000,"pid":1,"sessionId":"s1","tid":1,"depth":0,"asm":"App","ns":"MyNs","cls":"Svc","m":"Run","async":false,"deltaNs":5000000}"""
         ]);
 
-        var output = await CaptureOutputAsync(() =>
+        var output = await TestHelpers.CaptureConsoleOutputAsync(() =>
             DiffAnalyzer.AnalyzeAsync(_baseFile, _compareFile));
 
         Assert.Contains("Run", output);
@@ -54,7 +54,7 @@ public class DiffAnalysisTests : IAsyncLifetime
             """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"MyNs","cls":"Svc","m":"DoWork","callCount":100,"totalSelfNs":3000000,"maxSelfNs":100000,"totalInclusiveNs":5000000,"maxInclusiveNs":200000}"""
         ]);
 
-        var output = await CaptureOutputAsync(() =>
+        var output = await TestHelpers.CaptureConsoleOutputAsync(() =>
             DiffAnalyzer.AnalyzeAsync(_baseFile, _compareFile));
 
         Assert.Contains("DoWork", output);
@@ -75,7 +75,7 @@ public class DiffAnalysisTests : IAsyncLifetime
             """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"N","cls":"C","m":"NewMethod","callCount":5,"totalSelfNs":2000000,"maxSelfNs":400000,"totalInclusiveNs":3000000,"maxInclusiveNs":600000}"""
         ]);
 
-        var output = await CaptureOutputAsync(() =>
+        var output = await TestHelpers.CaptureConsoleOutputAsync(() =>
             DiffAnalyzer.AnalyzeAsync(_baseFile, _compareFile));
 
         Assert.Contains("NewMethod", output);
@@ -94,7 +94,7 @@ public class DiffAnalysisTests : IAsyncLifetime
             """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"N","cls":"C","m":"OtherMethod","callCount":1,"totalSelfNs":100000,"maxSelfNs":100000,"totalInclusiveNs":100000,"maxInclusiveNs":100000}"""
         ]);
 
-        var output = await CaptureOutputAsync(() =>
+        var output = await TestHelpers.CaptureConsoleOutputAsync(() =>
             DiffAnalyzer.AnalyzeAsync(_baseFile, _compareFile));
 
         Assert.Contains("RemovedMethod", output);
@@ -114,37 +114,37 @@ public class DiffAnalysisTests : IAsyncLifetime
             """{"event":"leave","tsNs":1000,"pid":1,"sessionId":"s1","tid":1,"depth":0,"asm":"App","ns":"N","cls":"C","m":"Repeat","async":false,"deltaNs":1000000}"""
         ]);
 
-        var output = await CaptureOutputAsync(() =>
+        var output = await TestHelpers.CaptureConsoleOutputAsync(() =>
             DiffAnalyzer.AnalyzeAsync(_baseFile, _compareFile));
 
         Assert.Contains("Repeat", output);
         // Base = 3ms + 2ms = 5ms, Compare = 1ms
-        Assert.Contains("ms", output);
-        Assert.Contains("Methods in base: 1", output);
+        Assert.Contains(AnalyzerHelpers.FormatNs(5_000_000), output);
+        Assert.Contains(AnalyzerHelpers.FormatNs(1_000_000), output);
     }
 
     [Fact]
-    public async Task MethodStats_UsesSelfTimeForComparison()
+    public async Task MethodStats_UsesInclusiveTimeForComparison()
     {
+        // Self-time is 7ms/3ms, inclusive is 50ms/40ms — verify inclusive is used
         await File.WriteAllLinesAsync(_baseFile,
         [
-            """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"N","cls":"C","m":"Target","callCount":10,"totalSelfNs":10000000,"maxSelfNs":1000000,"totalInclusiveNs":50000000,"maxInclusiveNs":5000000}"""
+            """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"N","cls":"C","m":"Target","callCount":10,"totalSelfNs":7000000,"maxSelfNs":700000,"totalInclusiveNs":50000000,"maxInclusiveNs":5000000}"""
         ]);
         await File.WriteAllLinesAsync(_compareFile,
         [
-            """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"N","cls":"C","m":"Target","callCount":10,"totalSelfNs":8000000,"maxSelfNs":800000,"totalInclusiveNs":40000000,"maxInclusiveNs":4000000}"""
+            """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"N","cls":"C","m":"Target","callCount":10,"totalSelfNs":3000000,"maxSelfNs":300000,"totalInclusiveNs":40000000,"maxInclusiveNs":4000000}"""
         ]);
 
-        var output = await CaptureOutputAsync(() =>
+        var output = await TestHelpers.CaptureConsoleOutputAsync(() =>
             DiffAnalyzer.AnalyzeAsync(_baseFile, _compareFile));
 
-        // Base should show 10ms (totalSelfNs=10_000_000), not 50ms (totalInclusiveNs)
-        var baseFmt = FormatNs(10_000_000);
-        var compareFmt = FormatNs(8_000_000);
-        Assert.Contains(baseFmt, output);
-        Assert.Contains(compareFmt, output);
-        // Should NOT contain 50ms (inclusive would be FormatNs(50_000_000))
-        Assert.DoesNotContain(FormatNs(50_000_000), output);
+        // Should use totalInclusiveNs (50ms/40ms), consistent with leave's deltaNs (also inclusive)
+        Assert.Contains(AnalyzerHelpers.FormatNs(50_000_000), output);
+        Assert.Contains(AnalyzerHelpers.FormatNs(40_000_000), output);
+        // Should NOT show self-time values (7ms/3ms)
+        Assert.DoesNotContain(AnalyzerHelpers.FormatNs(7_000_000), output);
+        Assert.DoesNotContain(AnalyzerHelpers.FormatNs(3_000_000), output);
     }
 
     [Fact]
@@ -153,7 +153,7 @@ public class DiffAnalysisTests : IAsyncLifetime
         await File.WriteAllTextAsync(_baseFile, "");
         await File.WriteAllTextAsync(_compareFile, "");
 
-        var output = await CaptureOutputAsync(() =>
+        var output = await TestHelpers.CaptureConsoleOutputAsync(() =>
             DiffAnalyzer.AnalyzeAsync(_baseFile, _compareFile));
 
         Assert.Contains("Methods in base: 0", output);
@@ -174,7 +174,7 @@ public class DiffAnalysisTests : IAsyncLifetime
             """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"N","cls":"C","m":"BigChange","callCount":10,"totalSelfNs":10000000,"maxSelfNs":1000000,"totalInclusiveNs":10000000,"maxInclusiveNs":1000000}"""
         ]);
 
-        var output = await CaptureOutputAsync(() =>
+        var output = await TestHelpers.CaptureConsoleOutputAsync(() =>
             DiffAnalyzer.AnalyzeAsync(_baseFile, _compareFile));
 
         var lines = output.Split('\n');
@@ -198,36 +198,33 @@ public class DiffAnalysisTests : IAsyncLifetime
             """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"N","cls":"C","m":"SlowMethod","callCount":1,"totalSelfNs":1000000000,"maxSelfNs":1000000000,"totalInclusiveNs":1000000000,"maxInclusiveNs":1000000000}"""
         ]);
 
-        var output = await CaptureOutputAsync(() =>
+        var output = await TestHelpers.CaptureConsoleOutputAsync(() =>
             DiffAnalyzer.AnalyzeAsync(_baseFile, _compareFile));
 
         // Should use FormatNs units (ns, us, ms, s) — not raw nanosecond numbers
         Assert.Contains("500ns", output);
-        Assert.Contains(FormatNs(2_000_000_000), output);
-        Assert.Contains(FormatNs(1_000_000_000), output);
+        Assert.Contains(AnalyzerHelpers.FormatNs(2_000_000_000), output);
+        Assert.Contains(AnalyzerHelpers.FormatNs(1_000_000_000), output);
     }
 
-    private static string FormatNs(long ns) => ns switch
+    [Fact]
+    public async Task MethodStats_KeyFormat_ConsistentWithHotspots()
     {
-        < 1_000 => $"{ns}ns",
-        < 1_000_000 => $"{ns / 1_000.0:F2}us",
-        < 1_000_000_000 => $"{ns / 1_000_000.0:F2}ms",
-        _ => $"{ns / 1_000_000_000.0:F2}s"
-    };
+        // Both analyzers should produce the same key format for the same method
+        await File.WriteAllLinesAsync(_baseFile,
+        [
+            """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"MyNs","cls":"MyClass","m":"DoWork","callCount":10,"totalSelfNs":5000000,"maxSelfNs":500000,"totalInclusiveNs":8000000,"maxInclusiveNs":800000}"""
+        ]);
+        await File.WriteAllLinesAsync(_compareFile,
+        [
+            """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"MyNs","cls":"MyClass","m":"DoWork","callCount":10,"totalSelfNs":3000000,"maxSelfNs":300000,"totalInclusiveNs":4000000,"maxInclusiveNs":400000}"""
+        ]);
 
-    private static async Task<string> CaptureOutputAsync(Func<Task> action)
-    {
-        var originalOut = Console.Out;
-        var sw = new StringWriter();
-        Console.SetOut(sw);
-        try
-        {
-            await action();
-            return sw.ToString();
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-        }
+        var diffOutput = await TestHelpers.CaptureConsoleOutputAsync(() =>
+            DiffAnalyzer.AnalyzeAsync(_baseFile, _compareFile));
+
+        // Key should be "MyNs.MyClass.DoWork" (no asm prefix), matching HotspotsAnalyzer
+        Assert.Contains("MyNs.MyClass.DoWork", diffOutput);
+        Assert.DoesNotContain("App.MyNs.MyClass.DoWork", diffOutput);
     }
 }

--- a/test/Metreja.IntegrationTests/Tests/HotspotsMethodStatsTests.cs
+++ b/test/Metreja.IntegrationTests/Tests/HotspotsMethodStatsTests.cs
@@ -29,7 +29,7 @@ public class HotspotsMethodStatsTests : IAsyncLifetime
             """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"MyNs","cls":"MyClass","m":"Helper","callCount":50,"totalSelfNs":2000000,"maxSelfNs":100000,"totalInclusiveNs":3000000,"maxInclusiveNs":150000}"""
         ]);
 
-        var output = await CaptureOutputAsync(() =>
+        var output = await TestHelpers.CaptureConsoleOutputAsync(() =>
             HotspotsAnalyzer.AnalyzeAsync(_tempFile, top: 10, minMs: 0, sortBy: "self", filters: []));
 
         Assert.Contains("DoWork", output);
@@ -47,7 +47,7 @@ public class HotspotsMethodStatsTests : IAsyncLifetime
             """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"N","cls":"C","m":"HighSelf","callCount":10,"totalSelfNs":5000000,"maxSelfNs":500000,"totalInclusiveNs":6000000,"maxInclusiveNs":600000}"""
         ]);
 
-        var output = await CaptureOutputAsync(() =>
+        var output = await TestHelpers.CaptureConsoleOutputAsync(() =>
             HotspotsAnalyzer.AnalyzeAsync(_tempFile, top: 10, minMs: 0, sortBy: "self", filters: []));
 
         var lines = output.Split('\n');
@@ -66,7 +66,7 @@ public class HotspotsMethodStatsTests : IAsyncLifetime
             """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"N","cls":"C","m":"LowIncl","callCount":10,"totalSelfNs":5000000,"maxSelfNs":500000,"totalInclusiveNs":2000000,"maxInclusiveNs":200000}"""
         ]);
 
-        var output = await CaptureOutputAsync(() =>
+        var output = await TestHelpers.CaptureConsoleOutputAsync(() =>
             HotspotsAnalyzer.AnalyzeAsync(_tempFile, top: 10, minMs: 0, sortBy: "inclusive", filters: []));
 
         var lines = output.Split('\n');
@@ -85,7 +85,7 @@ public class HotspotsMethodStatsTests : IAsyncLifetime
             """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"N","cls":"C","m":"ManyCalls","callCount":500,"totalSelfNs":1000000,"maxSelfNs":100000,"totalInclusiveNs":2000000,"maxInclusiveNs":200000}"""
         ]);
 
-        var output = await CaptureOutputAsync(() =>
+        var output = await TestHelpers.CaptureConsoleOutputAsync(() =>
             HotspotsAnalyzer.AnalyzeAsync(_tempFile, top: 10, minMs: 0, sortBy: "calls", filters: []));
 
         var lines = output.Split('\n');
@@ -104,7 +104,7 @@ public class HotspotsMethodStatsTests : IAsyncLifetime
             """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"MyNs","cls":"ServiceB","m":"Process","callCount":20,"totalSelfNs":3000000,"maxSelfNs":300000,"totalInclusiveNs":4000000,"maxInclusiveNs":400000}"""
         ]);
 
-        var output = await CaptureOutputAsync(() =>
+        var output = await TestHelpers.CaptureConsoleOutputAsync(() =>
             HotspotsAnalyzer.AnalyzeAsync(_tempFile, top: 10, minMs: 0, sortBy: "self", filters: ["ServiceA"]));
 
         Assert.Contains("DoWork", output);
@@ -120,7 +120,7 @@ public class HotspotsMethodStatsTests : IAsyncLifetime
             """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"N","cls":"C","m":"SlowMethod","callCount":10,"totalSelfNs":50000000,"maxSelfNs":5000000,"totalInclusiveNs":80000000,"maxInclusiveNs":8000000}"""
         ]);
 
-        var output = await CaptureOutputAsync(() =>
+        var output = await TestHelpers.CaptureConsoleOutputAsync(() =>
             HotspotsAnalyzer.AnalyzeAsync(_tempFile, top: 10, minMs: 1, sortBy: "self", filters: []));
 
         Assert.Contains("SlowMethod", output);
@@ -137,7 +137,7 @@ public class HotspotsMethodStatsTests : IAsyncLifetime
             """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"N","cls":"C","m":"MethodB","callCount":50,"totalSelfNs":5000000,"maxSelfNs":500000,"totalInclusiveNs":8000000,"maxInclusiveNs":800000}"""
         ]);
 
-        var output = await CaptureOutputAsync(() =>
+        var output = await TestHelpers.CaptureConsoleOutputAsync(() =>
             HotspotsAnalyzer.AnalyzeAsync(_tempFile, top: 10, minMs: 0, sortBy: "self", filters: []));
 
         Assert.Contains("MethodA", output);
@@ -154,25 +154,9 @@ public class HotspotsMethodStatsTests : IAsyncLifetime
             """{"event":"method_stats","tsNs":0,"pid":1,"sessionId":"s1","asm":"App","ns":"N","cls":"C","m":"M3","callCount":1,"totalSelfNs":3000000,"maxSelfNs":3000000,"totalInclusiveNs":3000000,"maxInclusiveNs":3000000}"""
         ]);
 
-        var output = await CaptureOutputAsync(() =>
+        var output = await TestHelpers.CaptureConsoleOutputAsync(() =>
             HotspotsAnalyzer.AnalyzeAsync(_tempFile, top: 10, minMs: 0, sortBy: "self", filters: []));
 
         Assert.Contains("3 methods", output);
-    }
-
-    private static async Task<string> CaptureOutputAsync(Func<Task> action)
-    {
-        var originalOut = Console.Out;
-        var sw = new StringWriter();
-        Console.SetOut(sw);
-        try
-        {
-            await action();
-            return sw.ToString();
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-        }
     }
 }

--- a/test/Metreja.IntegrationTests/Tests/TestHelpers.cs
+++ b/test/Metreja.IntegrationTests/Tests/TestHelpers.cs
@@ -1,0 +1,20 @@
+namespace Metreja.IntegrationTests.Tests;
+
+internal static class TestHelpers
+{
+    public static async Task<string> CaptureConsoleOutputAsync(Func<Task> action)
+    {
+        var originalOut = Console.Out;
+        var sw = new StringWriter();
+        Console.SetOut(sw);
+        try
+        {
+            await action();
+            return sw.ToString();
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **HotspotsAnalyzer**: reads `method_stats` events (maps `callCount`, `totalSelfNs`, `maxSelfNs`, `totalInclusiveNs`, `maxInclusiveNs` to existing `MethodStats` fields), enabling `metreja hotspots` to work natively on discovery sessions
- **DiffAnalyzer**: reads `method_stats` events (using `totalSelfNs` as comparison metric), sorts output by largest absolute delta, and formats times with `FormatNs()` instead of raw nanoseconds
- **17 new tests**: `HotspotsMethodStatsTests` (8) and `DiffAnalysisTests` (9) covering aggregation, sorting, filtering, mixed event types, and formatted output

## Test plan
- [x] Build succeeds with 0 warnings
- [x] All 17 new tests pass
- [x] Existing 4 `HotspotsAnalysisTests` still pass (backward compat)
- [x] Manual verification with real discovery NDJSON files (1022 methods shown)
- [x] Manual verification of analyze-diff with real before/after discovery files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for method_stats event type in performance analysis, enabling more detailed metric aggregation.
  * Diff analysis now displays change percentages alongside timing deltas for clearer comparisons.

* **Improvements**
  * Enhanced output formatting with readable time units and truncated method names.
  * Improved sorting to prioritize methods with largest timing changes.
  * Better handling of malformed input data.

* **Tests**
  * Added comprehensive integration test suites for diff and hotspots analysis functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->