### PR TITLE
feat: add report command for GitHub issue creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ Metreja is a two-component system:
 
 **Data flow:** CLI creates session config → `generate-env` sets profiler env vars → profiled app loads DLL → DLL writes NDJSON → CLI analysis commands read NDJSON.
 
+## Reporting Issues
+
+Report bugs or feature requests directly from the CLI:
+
+```bash
+metreja report --title "Bug: crash on empty trace" --description "Running hotspots on an empty NDJSON file causes an unhandled exception."
+```
+
+Requires the [GitHub CLI (`gh`)](https://cli.github.com/) to be installed and authenticated. Issues are created on the [kodroi/Metreja](https://github.com/kodroi/Metreja) repository.
+
 ## License
 
 [MIT](LICENSE) — Copyright (c) 2026 Iiro Rahkonen

--- a/src/Metreja.Tool/Commands/ReportCommand.cs
+++ b/src/Metreja.Tool/Commands/ReportCommand.cs
@@ -1,0 +1,121 @@
+using System.CommandLine;
+using System.Diagnostics;
+
+namespace Metreja.Tool.Commands;
+
+public static class ReportCommand
+{
+    private const string Repo = "kodroi/Metreja";
+
+    public static Command Create()
+    {
+        var titleOption = new Option<string>("--title", "-t")
+        {
+            Description = "Issue title",
+            Required = true
+        };
+
+        var descriptionOption = new Option<string>("--description", "-d")
+        {
+            Description = "Issue body/description",
+            Required = true
+        };
+
+        var command = new Command("report", "Report an issue to the GitHub repository");
+        command.Options.Add(titleOption);
+        command.Options.Add(descriptionOption);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var title = parseResult.GetValue(titleOption)!;
+            var description = parseResult.GetValue(descriptionOption)!;
+
+            // 1. Check if gh is installed
+            if (!await IsGhInstalled())
+            {
+                Console.Error.WriteLine(
+                    "Error: GitHub CLI (gh) is not installed. Install it from https://cli.github.com/ and ensure it is on your PATH.");
+                return 2;
+            }
+
+            // 2. Check if gh is authenticated
+            if (!await IsGhAuthenticated(cancellationToken))
+            {
+                Console.Error.WriteLine(
+                    "Error: GitHub CLI is not authenticated. Run 'gh auth login' to authenticate.");
+                return 3;
+            }
+
+            // 3. Create the issue
+            var (exitCode, stdout, stderr) = await RunGh(
+                $"issue create --repo {Repo} --title \"{EscapeArg(title)}\" --body \"{EscapeArg(description)}\"",
+                cancellationToken);
+
+            if (exitCode == 0)
+            {
+                Console.WriteLine(stdout.Trim());
+                return 0;
+            }
+
+            Console.Error.WriteLine(stderr.Trim());
+            return 1;
+        });
+
+        return command;
+    }
+
+    private static async Task<bool> IsGhInstalled()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "gh",
+                Arguments = "--version",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+            using var process = Process.Start(psi);
+            if (process == null) return false;
+            await process.WaitForExitAsync();
+            return true;
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            return false;
+        }
+    }
+
+    private static async Task<bool> IsGhAuthenticated(CancellationToken cancellationToken)
+    {
+        var (exitCode, _, _) = await RunGh("auth status", cancellationToken);
+        return exitCode == 0;
+    }
+
+    private static async Task<(int ExitCode, string Stdout, string Stderr)> RunGh(
+        string arguments, CancellationToken cancellationToken)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "gh",
+            Arguments = arguments,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(psi)!;
+        var stdout = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stderr = await process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken);
+        return (process.ExitCode, stdout, stderr);
+    }
+
+    private static string EscapeArg(string value)
+    {
+        return value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+    }
+}

--- a/src/Metreja.Tool/Program.cs
+++ b/src/Metreja.Tool/Program.cs
@@ -17,6 +17,7 @@ rootCommand.Subcommands.Add(HotspotsCommand.Create());
 rootCommand.Subcommands.Add(CallTreeCommand.Create());
 rootCommand.Subcommands.Add(CallersCommand.Create());
 rootCommand.Subcommands.Add(MemoryCommand.Create());
+rootCommand.Subcommands.Add(ReportCommand.Create());
 
 var parseResult = rootCommand.Parse(args);
 var exitCode = await parseResult.InvokeAsync();

--- a/src/Metreja.Tool/README.md
+++ b/src/Metreja.Tool/README.md
@@ -277,6 +277,25 @@ Compare two traces. Shows per-method timing delta (base vs. compare).
 | `base` | string | **Required.** Base NDJSON file |
 | `compare` | string | **Required.** Comparison NDJSON file |
 
+#### `report`
+
+Report an issue to the GitHub repository. Requires the [GitHub CLI (`gh`)](https://cli.github.com/) installed and authenticated.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `-t`, `--title` | string | — | **Required.** Issue title |
+| `-d`, `--description` | string | — | **Required.** Issue body/description |
+
+```bash
+metreja report --title "Bug: crash on empty trace" --description "Detailed description of the issue."
+```
+
+**Exit codes:**
+- `0` — Issue created successfully
+- `1` — Issue creation failed (prints GitHub error)
+- `2` — GitHub CLI not installed
+- `3` — GitHub CLI not authenticated
+
 ### Session Config Format
 
 Stored at `.metreja/sessions/{sessionId}.json`:


### PR DESCRIPTION
## Summary
- Adds `metreja report --title "..." --description "..."` command that creates GitHub issues on `kodroi/Metreja` via the `gh` CLI
- Validates `gh` is installed (exit 2) and authenticated (exit 3) before attempting issue creation
- Updates both READMEs with command documentation

## Test plan
- [ ] `dotnet build` succeeds with 0 warnings
- [ ] `metreja report --title "Test" --description "Test"` creates an issue
- [ ] Without `gh` installed: exits with code 2
- [ ] Without `gh` auth: exits with code 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "report" command to submit issues directly to the repository via GitHub CLI. Requires GitHub CLI to be installed and authenticated.

* **Documentation**
  * Updated README with guidance on reporting issues, including command options, usage examples, and prerequisite setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->