### PR TITLE
feat: production-like profiling defaults with inlining/optimization controls

### DIFF
--- a/src/Metreja.Profiler/ConfigReader.cpp
+++ b/src/Metreja.Profiler/ConfigReader.cpp
@@ -78,6 +78,8 @@ ProfilerConfig ConfigReader::Load()
             config.computeDeltas = inst["computeDeltas"].get<bool>();
         if (inst.contains("disableInlining"))
             config.disableInlining = inst["disableInlining"].get<bool>();
+        if (inst.contains("disableOptimizations"))
+            config.disableOptimizations = inst["disableOptimizations"].get<bool>();
         if (inst.contains("statsFlushIntervalSeconds"))
             config.statsFlushIntervalSeconds = inst["statsFlushIntervalSeconds"].get<int>();
 

--- a/src/Metreja.Profiler/ConfigReader.h
+++ b/src/Metreja.Profiler/ConfigReader.h
@@ -49,7 +49,8 @@ struct ProfilerConfig
     std::string outputPath = ".metreja/output/{sessionId}_{pid}.ndjson";
     int64_t maxEvents = 0;
     bool computeDeltas = true;
-    bool disableInlining = true;
+    bool disableInlining = false;
+    bool disableOptimizations = false;
     EventType enabledEvents = EventType::None;
     int statsFlushIntervalSeconds = 30;
     std::vector<FilterRule> includes;

--- a/src/Metreja.Profiler/Profiler.cpp
+++ b/src/Metreja.Profiler/Profiler.cpp
@@ -224,6 +224,9 @@ HRESULT MetrejaProfiler::SetupEventMonitoring(EventType events)
     if (g_ctx->config.disableInlining)
         eventMask |= COR_PRF_DISABLE_INLINING;
 
+    if (g_ctx->config.disableOptimizations)
+        eventMask |= COR_PRF_DISABLE_OPTIMIZATIONS;
+
     // Single consolidated SetEventMask call
     HRESULT hr;
     if (m_profilerInfo5 != nullptr && highFlags != 0)

--- a/src/Metreja.Tool/Commands/SetCommand.cs
+++ b/src/Metreja.Tool/Commands/SetCommand.cs
@@ -17,6 +17,8 @@ public static class SetCommand
         command.Subcommands.Add(CreateComputeDeltasCommand(sessionOption));
         command.Subcommands.Add(CreateEventsCommand(sessionOption));
         command.Subcommands.Add(CreateStatsFlushIntervalCommand(sessionOption));
+        command.Subcommands.Add(CreateDisableInliningCommand(sessionOption));
+        command.Subcommands.Add(CreateDisableOptimizationsCommand(sessionOption));
 
         return command;
     }
@@ -178,6 +180,48 @@ public static class SetCommand
                 $"stats-flush-interval to: {value}s");
 
             return 0;
+        });
+
+        return command;
+    }
+
+    private static Command CreateDisableInliningCommand(Option<string> sessionOption)
+    {
+        var valueArg = new Argument<bool>("value") { Description = "Disable JIT inlining (default: false). Set to true for complete method-level tracing" };
+
+        var command = new Command("disable-inlining", "Control JIT inlining during profiling");
+        command.Options.Add(sessionOption);
+        command.Arguments.Add(valueArg);
+
+        command.SetAction(async (parseResult, _) =>
+        {
+            var session = parseResult.GetValue(sessionOption)!;
+            var value = parseResult.GetValue(valueArg);
+
+            await SetConfigPropertyAsync(session,
+                config => config with { Instrumentation = config.Instrumentation with { DisableInlining = value } },
+                $"disable-inlining to: {value}");
+        });
+
+        return command;
+    }
+
+    private static Command CreateDisableOptimizationsCommand(Option<string> sessionOption)
+    {
+        var valueArg = new Argument<bool>("value") { Description = "Disable JIT optimizations (default: false). Set to true for debug-level tracing" };
+
+        var command = new Command("disable-optimizations", "Control JIT optimizations during profiling");
+        command.Options.Add(sessionOption);
+        command.Arguments.Add(valueArg);
+
+        command.SetAction(async (parseResult, _) =>
+        {
+            var session = parseResult.GetValue(sessionOption)!;
+            var value = parseResult.GetValue(valueArg);
+
+            await SetConfigPropertyAsync(session,
+                config => config with { Instrumentation = config.Instrumentation with { DisableOptimizations = value } },
+                $"disable-optimizations to: {value}");
         });
 
         return command;

--- a/src/Metreja.Tool/Config/ProfilerConfig.cs
+++ b/src/Metreja.Tool/Config/ProfilerConfig.cs
@@ -32,7 +32,10 @@ public record InstrumentationConfig
     public bool ComputeDeltas { get; init; } = true;
 
     [JsonPropertyName("disableInlining")]
-    public bool DisableInlining { get; init; } = true;
+    public bool DisableInlining { get; init; } = false;
+
+    [JsonPropertyName("disableOptimizations")]
+    public bool DisableOptimizations { get; init; } = false;
 
     [JsonPropertyName("statsFlushIntervalSeconds")]
     public int StatsFlushIntervalSeconds { get; init; } = 30;

--- a/test/Metreja.IntegrationTests/Tests/SessionManagementTests.cs
+++ b/test/Metreja.IntegrationTests/Tests/SessionManagementTests.cs
@@ -34,7 +34,7 @@ public class SessionManagementTests : IAsyncLifetime
         Assert.Equal("round-trip-test", config.Metadata.Scenario);
         Assert.Equal(0, config.Instrumentation.MaxEvents);
         Assert.True(config.Instrumentation.ComputeDeltas);
-        Assert.True(config.Instrumentation.DisableInlining);
+        Assert.False(config.Instrumentation.DisableInlining);
         Assert.Equal(30, config.Instrumentation.StatsFlushIntervalSeconds);
         Assert.Null(config.Instrumentation.Events);
         Assert.Empty(config.Instrumentation.Includes);
@@ -350,6 +350,147 @@ public class SessionManagementTests : IAsyncLifetime
         var config = await manager.LoadConfigAsync(sessionId);
 
         Assert.Equal("", config.Metadata.Scenario);
+    }
+
+    [Fact]
+    public async Task DisableInlining_DefaultsFalse()
+    {
+        var manager = new ConfigManager(_tempDir);
+        var sessionId = await manager.CreateSessionAsync("inlining-default-test");
+
+        var config = await manager.LoadConfigAsync(sessionId);
+
+        Assert.False(config.Instrumentation.DisableInlining);
+    }
+
+    [Fact]
+    public async Task DisableInlining_SetTrue_PersistsCorrectly()
+    {
+        var manager = new ConfigManager(_tempDir);
+        var sessionId = await manager.CreateSessionAsync("inlining-disable-test");
+
+        var config = await manager.LoadConfigAsync(sessionId);
+        config = config with
+        {
+            Instrumentation = config.Instrumentation with { DisableInlining = true }
+        };
+        await manager.SaveConfigAsync(sessionId, config);
+
+        var reloaded = await manager.LoadConfigAsync(sessionId);
+        Assert.True(reloaded.Instrumentation.DisableInlining);
+    }
+
+    [Fact]
+    public async Task DisableInlining_SetFalse_PersistsCorrectly()
+    {
+        var manager = new ConfigManager(_tempDir);
+        var sessionId = await manager.CreateSessionAsync("inlining-enable-test");
+
+        // First set to true
+        var config = await manager.LoadConfigAsync(sessionId);
+        config = config with
+        {
+            Instrumentation = config.Instrumentation with { DisableInlining = true }
+        };
+        await manager.SaveConfigAsync(sessionId, config);
+
+        // Then set back to false
+        config = await manager.LoadConfigAsync(sessionId);
+        config = config with
+        {
+            Instrumentation = config.Instrumentation with { DisableInlining = false }
+        };
+        await manager.SaveConfigAsync(sessionId, config);
+
+        var reloaded = await manager.LoadConfigAsync(sessionId);
+        Assert.False(reloaded.Instrumentation.DisableInlining);
+    }
+
+    [Fact]
+    public async Task DisableInlining_PreservesOtherSettings()
+    {
+        var manager = new ConfigManager(_tempDir);
+        var sessionId = await manager.CreateSessionAsync("inlining-preserve-test");
+
+        // Set events and max-events first
+        var config = await manager.LoadConfigAsync(sessionId);
+        config = config with
+        {
+            Instrumentation = config.Instrumentation with
+            {
+                Events = ["enter", "leave", "method_stats"],
+                MaxEvents = 50000
+            }
+        };
+        await manager.SaveConfigAsync(sessionId, config);
+
+        // Now toggle disable-inlining
+        config = await manager.LoadConfigAsync(sessionId);
+        config = config with
+        {
+            Instrumentation = config.Instrumentation with { DisableInlining = true }
+        };
+        await manager.SaveConfigAsync(sessionId, config);
+
+        // Verify other settings are preserved
+        var reloaded = await manager.LoadConfigAsync(sessionId);
+        Assert.True(reloaded.Instrumentation.DisableInlining);
+        Assert.Equal(50000, reloaded.Instrumentation.MaxEvents);
+        Assert.NotNull(reloaded.Instrumentation.Events);
+        Assert.Equal(3, reloaded.Instrumentation.Events!.Count);
+        Assert.Contains("method_stats", reloaded.Instrumentation.Events);
+    }
+
+    [Fact]
+    public async Task DisableOptimizations_DefaultsFalse()
+    {
+        var manager = new ConfigManager(_tempDir);
+        var sessionId = await manager.CreateSessionAsync("optimizations-default-test");
+
+        var config = await manager.LoadConfigAsync(sessionId);
+
+        Assert.False(config.Instrumentation.DisableOptimizations);
+    }
+
+    [Fact]
+    public async Task DisableOptimizations_SetTrue_PersistsCorrectly()
+    {
+        var manager = new ConfigManager(_tempDir);
+        var sessionId = await manager.CreateSessionAsync("optimizations-disable-test");
+
+        var config = await manager.LoadConfigAsync(sessionId);
+        config = config with
+        {
+            Instrumentation = config.Instrumentation with { DisableOptimizations = true }
+        };
+        await manager.SaveConfigAsync(sessionId, config);
+
+        var reloaded = await manager.LoadConfigAsync(sessionId);
+        Assert.True(reloaded.Instrumentation.DisableOptimizations);
+    }
+
+    [Fact]
+    public async Task DisableOptimizations_SetFalse_PersistsCorrectly()
+    {
+        var manager = new ConfigManager(_tempDir);
+        var sessionId = await manager.CreateSessionAsync("optimizations-enable-test");
+
+        var config = await manager.LoadConfigAsync(sessionId);
+        config = config with
+        {
+            Instrumentation = config.Instrumentation with { DisableOptimizations = true }
+        };
+        await manager.SaveConfigAsync(sessionId, config);
+
+        config = await manager.LoadConfigAsync(sessionId);
+        config = config with
+        {
+            Instrumentation = config.Instrumentation with { DisableOptimizations = false }
+        };
+        await manager.SaveConfigAsync(sessionId, config);
+
+        var reloaded = await manager.LoadConfigAsync(sessionId);
+        Assert.False(reloaded.Instrumentation.DisableOptimizations);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Change `disableInlining` default from `true` to `false` — profiling now reflects real-world JIT behavior
- Change `disableOptimizations` default to `false` (was already not set, now explicit)
- Add `metreja set disable-inlining` CLI command
- Add `metreja set disable-optimizations` CLI command
- Add C++ config reading and `COR_PRF_DISABLE_OPTIMIZATIONS` event mask support
- Add 7 new integration tests covering both flags

## Problem

The profiler previously always set `COR_PRF_DISABLE_INLINING`, preventing the JIT from inlining methods. This inflated per-call overhead for small `AggressiveInlining` methods and produced misleading hotspot data — e.g., ImageSharp's `PermuteW` and `WithW` appeared as billion-call hotspots but are fully inlined in production.

## Usage

```bash
# Default: production-like (inlining + optimizations enabled)
metreja init --scenario perf-test

# Full method tracing (every call visible, no inlining)
metreja set disable-inlining -s $SESSION true

# Debug-level tracing (no optimizations at all)
metreja set disable-optimizations -s $SESSION true
```

## Files changed

- `src/Metreja.Tool/Config/ProfilerConfig.cs` — default `false` for both flags
- `src/Metreja.Tool/Commands/SetCommand.cs` — two new CLI commands
- `src/Metreja.Profiler/ConfigReader.h` — new `disableOptimizations` field
- `src/Metreja.Profiler/ConfigReader.cpp` — parse new field from JSON
- `src/Metreja.Profiler/Profiler.cpp` — set `COR_PRF_DISABLE_OPTIMIZATIONS` when configured
- `test/Metreja.IntegrationTests/Tests/SessionManagementTests.cs` — 7 new tests

## Test plan

- [x] 165 integration tests pass (158 existing + 7 new)
- [x] `set disable-inlining` writes correct JSON config
- [x] `set disable-optimizations` writes correct JSON config
- [x] Both default to `false` (production-like)
- [x] Toggling one flag preserves all other settings