### PR TITLE
ci: auto-stamp changelog version on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,16 @@ jobs:
       - name: Display version
         run: echo "Publishing version ${{ steps.gitversion.outputs.semVer }}"
 
+      - name: Stamp changelog version
+        run: |
+          VERSION="${{ steps.gitversion.outputs.semVer }}"
+          DATE=$(date +%Y-%m-%d)
+          sed -i "s/^## Unreleased$/## Unreleased\n\n## [$VERSION] — $DATE/" CHANGELOG.md
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --cached --quiet || (git commit -m "docs: stamp changelog v$VERSION" && git push)
+
       - name: Setup .NET 10
         uses: actions/setup-dotnet@v5
         with:


### PR DESCRIPTION
## Summary
- Publish workflow now replaces `## Unreleased` with `## [x.y.z] — date` using the GitVersion semver
- Adds a fresh `## Unreleased` heading above it for the next cycle
- No-op if `## Unreleased` doesn't exist in the changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)